### PR TITLE
Merging multiple pdfs results in warning

### DIFF
--- a/pdfgen/pdfgen.py
+++ b/pdfgen/pdfgen.py
@@ -83,7 +83,7 @@ class PDFGen(object):
             await self.browser.close()
 
         if count > 1:
-            result = self.merge_pdfs(result, path)
+            result = await self.merge_pdfs(result, path)
         else:
             if is_iterable(result):
                 result = result[0]


### PR DESCRIPTION
When using in async worker following error is triggered:

     coroutine 'PDFGen.merge_pdfs' was never awaited