### PR TITLE
Settings for page or browser context.

### DIFF
--- a/pdfgen/configuration.py
+++ b/pdfgen/configuration.py
@@ -7,9 +7,9 @@ from collections import OrderedDict
 
 class Configuration(object):
     def __init__(self, options={}, pyppeteer={}, meta_tag_prefix='pdfgen-', environ=''):
-        self.update(options, settings, meta_tag_prefix, environ)
+        self.update(options, pyppeteer, meta_tag_prefix, environ)
 
-    def update(self, options=None, pyppeteer=None, meta_tag_prefix=None, environ=None):
+    def update(self, options=None, pyppeteer={}, meta_tag_prefix=None, environ=None):
         if meta_tag_prefix is not None:
             self.meta_tag_prefix = meta_tag_prefix
 
@@ -24,16 +24,10 @@ class Configuration(object):
         if options is not None:
             self.options = OrderedDict(options)
 
-        if pyppeteer is not None:
-            self.pyppeteer = OrderedDict(pyppeteer)
-
-        pageOptions = self.pyppeteer.get('pageOptions', None)
-        if pageOptions:
-            self.page_options = pageOptions
-
-        browserArgs = self.pyppeteer.get('browserArgs', None)
-        if pageOptions:
-            self.browser_args = browserArgs
+        # Always pass on empty dict
+        self.pyppeteer = OrderedDict(pyppeteer)
+        self.page_options = self.pyppeteer.get('pageOptions', None)
+        self.browser_args = self.pyppeteer.get('browserArgs', [])
 
         return self
 

--- a/pdfgen/configuration.py
+++ b/pdfgen/configuration.py
@@ -6,10 +6,10 @@ from collections import OrderedDict
 
 
 class Configuration(object):
-    def __init__(self, options={}, meta_tag_prefix='pdfgen-', environ=''):
-        self.update(options, meta_tag_prefix, environ)
+    def __init__(self, options={}, settings={}, meta_tag_prefix='pdfgen-', environ=''):
+        self.update(options, settings, meta_tag_prefix, environ)
 
-    def update(self, options=None, meta_tag_prefix=None, environ=None):
+    def update(self, options=None, settings=None, meta_tag_prefix=None, environ=None):
         if meta_tag_prefix is not None:
             self.meta_tag_prefix = meta_tag_prefix
 
@@ -23,6 +23,9 @@ class Configuration(object):
 
         if options is not None:
             self.options = OrderedDict(options)
+
+        if settings is not None:
+            self.settings = OrderedDict(settings)
 
         return self
 

--- a/pdfgen/configuration.py
+++ b/pdfgen/configuration.py
@@ -6,10 +6,10 @@ from collections import OrderedDict
 
 
 class Configuration(object):
-    def __init__(self, options={}, settings={}, meta_tag_prefix='pdfgen-', environ=''):
+    def __init__(self, options={}, pyppeteer={}, meta_tag_prefix='pdfgen-', environ=''):
         self.update(options, settings, meta_tag_prefix, environ)
 
-    def update(self, options=None, settings=None, meta_tag_prefix=None, environ=None):
+    def update(self, options=None, pyppeteer=None, meta_tag_prefix=None, environ=None):
         if meta_tag_prefix is not None:
             self.meta_tag_prefix = meta_tag_prefix
 
@@ -24,12 +24,22 @@ class Configuration(object):
         if options is not None:
             self.options = OrderedDict(options)
 
-        if settings is not None:
-            self.settings = OrderedDict(settings)
+        if pyppeteer is not None:
+            self.pyppeteer = OrderedDict(pyppeteer)
+
+        pageOptions = self.pyppeteer.get('pageOptions', None)
+        if pageOptions:
+            self.page_options = pageOptions
+
+        browserArgs = self.pyppeteer.get('browserArgs', None)
+        if pageOptions:
+            self.browser_args = browserArgs
 
         return self
 
+
 DEFAULT_CONFIG = Configuration()
+
 
 def configuration(**kwargs):
     """

--- a/pdfgen/pdfgen.py
+++ b/pdfgen/pdfgen.py
@@ -30,6 +30,7 @@ class PDFGen(object):
         self.sources = sources if is_iterable(sources) else [sources]
         self.configuration = DEFAULT_CONFIG
         self.options = self.configuration.options
+        self.settings = self.configuration.settings
         self.environ = self.configuration.environ
         if options is not None:
             self.options.update(options)
@@ -38,6 +39,13 @@ class PDFGen(object):
         is_stdout = (not output_path) or (output_path == '-')
         try:
             page = await self.browser.newPage()
+
+            settings = self.settings
+            emulateMediaType = settings.get('emulateMedia', None)
+            if emulateMediaType:
+               await page.emulateMedia(emulateMediaType)
+
+
             if source.isString():
                 await page.setContent(source.to_s())
             elif source.isFileObj():

--- a/tests/test_pyppeteer_settings.py
+++ b/tests/test_pyppeteer_settings.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import codecs
+import io
+import os
+import sys
+import unittest
+
+import pytest
+
+import asynctest
+import pdfgen
+
+from pdfgen import PDFGen
+import pytest_asyncio.plugin
+from pdfgen.errors import InvalidSourceError
+
+TEST_PATH = os.path.dirname(os.path.realpath(__file__))
+
+PYPPETEER_EXTRA_SETTINGS = {
+    'browserArgs': [' --webkit-print-color-adjust'],
+    'pageOptions': {'waitUntil': 'networkidle2'},
+}
+
+PYPPETEER_EMULATE_MEDIA_SETTINGS = {
+    'emulateMedia': 'screen',
+}
+
+
+class TestPdfPyppeteerSettings(asynctest.TestCase):
+    """Test pyppeteer settings"""
+
+    @pytest.mark.asyncio
+    async def test_pdf_page_emulate_media_setting(self):
+        config = pdfgen.configuration(pyppeteer=PYPPETEER_EMULATE_MEDIA_SETTINGS)
+        pdf = await pdfgen.from_url(
+            'http://networkcheck.kde.org', 'out.pdf', options={'printBackground': True}
+        )
+
+        self.assertEqual(config.pyppeteer['emulateMedia'], 'screen')
+
+
+if __name__ == "__main__":
+    asynctest.main()


### PR DESCRIPTION
Open for discussion, but the general idea is to add `settings` dict to `pdf.configuration`. 
This way we can pass settings to page, browser and more.

For example to handle issue [How to set page.emulateMedia('screen')? #3](https://github.com/shivanshs9/pdfgen-python/issues/3)

      import pdfgen
      
      pdfgen.configuration(settings={'emulateMedia': 'screen'})


Another example:

      import pdfgen
      
      pdfgen.configuration(settings={'setBypassCSP': True})


I think there should be a list of page & browser options that are relevant for `Page.pdf`:

- Page.emulateMedia
- Page.setBypassCSP
- Page.setCookie

To wait for the page
- Page.goto{waitUntil}

To block / intercept certain requests
- Page.setRequestInterception
- Page.on('request')
